### PR TITLE
Fixed safari mobile menu bug

### DIFF
--- a/style.css
+++ b/style.css
@@ -1904,6 +1904,9 @@ footer i {
   .dropdown .dropbtn {
     display: none;
   }
+  span.icon.hamburger {
+    float: right;
+  }
   .topnav span.icon {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
On IOS only, if you open the mobile menu the hamburger will be off center when closed.  Addressed in this PR.